### PR TITLE
don't allow people to send messages when websockets aren't ready

### DIFF
--- a/views/application.js.erb
+++ b/views/application.js.erb
@@ -18,6 +18,14 @@ function createWebsocket() {
       scrollTop: $('#chat-text')[0].scrollHeight
     }, 800);
   };
+
+  ws.onopen = function(event) {
+    $("#chat-button").attr('disabled', false);
+  }
+
+  ws.onclose = function(event) {
+    $("#chat-button").attr('disabled', true);
+  }
 }
 
 $("#channel-form").on("submit", function(event) {

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -26,7 +26,7 @@
         <div class="form-group">
           <input id="input-text" type="text" class="form-control" placeholder="Enter chat text here!" autofocus />
         </div>
-        <button class="btn btn-primary" type="submit">Send</button>
+        <button id="chat-button" class="btn btn-primary" type="submit" disabled>Send</button>
       </form>
       <div class="page-header">
         <h1>Chat</h1>


### PR DESCRIPTION
Before messages aren't being queued/handled and they will be missed if the websocket isn't ready. This prevents users' from trying to send them into the void.
